### PR TITLE
Generate slug for level

### DIFF
--- a/.run/puzzleeditor2020 - local.run.xml
+++ b/.run/puzzleeditor2020 - local.run.xml
@@ -1,0 +1,29 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="puzzleeditor2020 - local" type="Python.DjangoServer" factoryName="Django server">
+    <module name="MAGiE Web" />
+    <option name="ENV_FILES" value="" />
+    <option name="INTERPRETER_OPTIONS" value="" />
+    <option name="PARENT_ENVS" value="true" />
+    <envs>
+      <env name="DJANGO_SETTINGS_MODULE" value="magie_online.settings.local" />
+      <env name="PYTHONUNBUFFERED" value="1" />
+      <env name="DJANGO_SECRET_KEY" value="export DJANGO_SECRET_KEY='OEjY9%TA9%HF4Ud09eCuOpnFeKvpLj2i&amp;mdz209FbVfoxDF7XK' " />
+    </envs>
+    <option name="SDK_HOME" value="" />
+    <option name="SDK_NAME" value="Python 3.12 (puzzleeditor2020)" />
+    <option name="WORKING_DIRECTORY" value="" />
+    <option name="IS_MODULE_SDK" value="false" />
+    <option name="ADD_CONTENT_ROOTS" value="true" />
+    <option name="ADD_SOURCE_ROOTS" value="true" />
+    <option name="launchJavascriptDebuger" value="false" />
+    <option name="port" value="8000" />
+    <option name="host" value="puzzleeditor2020.local" />
+    <option name="additionalOptions" value="" />
+    <option name="browserUrl" value="" />
+    <option name="runTestServer" value="false" />
+    <option name="runNoReload" value="false" />
+    <option name="useCustomRunCommand" value="false" />
+    <option name="customRunCommand" value="" />
+    <method v="2" />
+  </configuration>
+</component>

--- a/puzzles/admin.py
+++ b/puzzles/admin.py
@@ -71,7 +71,9 @@ class PuzzleAdmin(admin.ModelAdmin):
     return None
 
   def level_category(self, puzzle):
-    return f'{puzzle.level.category.menu.name}/{puzzle.level.category.name}' if puzzle.level.category else ''
+    if puzzle.level.category and puzzle.level.category.menu:
+      return f'{puzzle.level.category.menu.name}/{puzzle.level.category.name}'
+    return ''
 
   daily_puzzle_link.short_description = 'Puzzle on Date'
 

--- a/puzzles/admin.py
+++ b/puzzles/admin.py
@@ -68,6 +68,7 @@ class PuzzleAdmin(admin.ModelAdmin):
     if daily_puzzle:
       url = reverse('admin:puzzles_dailypuzzle_change', args=[daily_puzzle.id])
       return format_html(f'<a href="{url}">{daily_puzzle.date}</a>')
+    return None
 
   def level_category(self, puzzle):
     return puzzle.level.category.menu.name if puzzle.level.category else ''

--- a/puzzles/admin.py
+++ b/puzzles/admin.py
@@ -71,7 +71,7 @@ class PuzzleAdmin(admin.ModelAdmin):
     return None
 
   def level_category(self, puzzle):
-    return puzzle.level.category.menu.name if puzzle.level.category else ''
+    return f'{puzzle.level.category.menu.name}/{puzzle.level.category.name}' if puzzle.level.category else ''
 
   daily_puzzle_link.short_description = 'Puzzle on Date'
 

--- a/puzzles/models.py
+++ b/puzzles/models.py
@@ -161,7 +161,6 @@ class ClueLine(Line):
     if not self.sort_order:
       self.sort_order = self.clue_in.clue.count()
 
-    self.text = self.text.upper()
     super().save(*args, **kwargs)
 
 

--- a/puzzles/models.py
+++ b/puzzles/models.py
@@ -190,3 +190,11 @@ class DailyPuzzle(models.Model):
 
   def encoding(self):
     return self.puzzle.encoding
+
+  @property
+  def get_menu_name(self):
+    if self.puzzle and self.puzzle.level and self.puzzle.level.category and self.puzzle.level.category.menu:
+      return self.puzzle.level.category.menu.name
+    return None
+
+

--- a/puzzles/urls.py
+++ b/puzzles/urls.py
@@ -5,7 +5,6 @@ from django.urls import path
 from . import views
 
 urlpatterns = [
-  path('', views.PuzzlesListView.as_view()),
   path('<pk>', views.PuzzleDetailView.as_view()),
   path('today/', views.DailyPuzzleView.as_view()),
   path('daily/<year>/<month>/<day>/', views.DailyPuzzleTest.as_view()),


### PR DESCRIPTION
auto-generate a slug for a level if one isn't present.

I'm worried that when we save the level to get it's auto-numbered "level number" primary key, the app will not let it save because it doesn't have a unique slug.
