### PR TITLE
also generate the level slug if it has a generic value like 'level-001'

### DIFF
--- a/puzzles/models.py
+++ b/puzzles/models.py
@@ -84,7 +84,7 @@ class Level(models.Model):
     if (
       (not self.slug)
       or
-      (self.levelName and self.levelName.count() > 0
+      (self.levelName and len(self.levelName > 0)
        and
        self.slug == f'level-{self.levelNumber}')
     ):

--- a/puzzles/models.py
+++ b/puzzles/models.py
@@ -82,11 +82,7 @@ class Level(models.Model):
       super().save(*args, **kwargs)
     # Now generate the slug if needed
     if (
-      (not self.slug)
-      or
-      (self.levelName and len(self.levelName > 0)
-       and
-       self.slug == f'level-{self.levelNumber}')
+      self.should_update_slug()
     ):
       self.slug = self.generate_default_slug()
       # Save again only if the slug was just set
@@ -94,6 +90,14 @@ class Level(models.Model):
     else:
       # If slug already exists, just save as normal
       super().save(*args, **kwargs)
+
+  def should_update_slug(self):
+    if not self.slug:
+      return True
+
+    return (self.levelName and len(self.levelName > 0)
+     and
+     self.slug == f'level-{self.levelNumber}')
 
   class Meta:
     ordering = ['category', 'sort_order']

--- a/puzzles/models.py
+++ b/puzzles/models.py
@@ -81,7 +81,13 @@ class Level(models.Model):
     if not self.pk:
       super().save(*args, **kwargs)
     # Now generate the slug if needed
-    if not self.slug:
+    if (
+      (not self.slug)
+      or
+      (self.levelName and self.levelName.count() > 0
+       and
+       self.slug == f'level-{self.levelNumber}')
+    ):
       self.slug = self.generate_default_slug()
       # Save again only if the slug was just set
       super().save(update_fields=['slug'])
@@ -192,9 +198,7 @@ class DailyPuzzle(models.Model):
     return self.puzzle.encoding
 
   @property
-  def get_menu_name(self):
+  def menu_name(self):
     if self.puzzle and self.puzzle.level and self.puzzle.level.category and self.puzzle.level.category.menu:
       return self.puzzle.level.category.menu.name
     return None
-
-


### PR DESCRIPTION
* Updated the `save` method to regenerate the slug if it matches a specific default pattern (`level-{self.levelNumber}`) and the `levelName` has some lines to use.

* Renamed the `get_menu_name` property to `menu_name` for better alignment with Python property naming conventions, improving code clarity and readability.