### PR TITLE
add line counter functionality for dynamically added inputs

### DIFF
--- a/puzzles/static/js/char_counter.js
+++ b/puzzles/static/js/char_counter.js
@@ -107,6 +107,7 @@ class CharCounter {
 		const newInputs = event.target.querySelectorAll(charCounter.inputSelector);
 		newInputs.forEach(input => {
 			charCounter.attachToInput(input);
+			charCounter.updateCharCountLabel(input);
 		});
 	});
 })();

--- a/puzzles/static/js/char_counter.js
+++ b/puzzles/static/js/char_counter.js
@@ -9,11 +9,11 @@ class CharCounter {
 	onDomLoaded() {
 		this.lineInputs = this.selectLineInputs();
 		this.lineLengthInput = this.selectLineLengthInput();
+		this.lineLength = this.lineLengthInput.value;
 
 		this.listenForLineChanges();
 		this.listenForLineLengthChanges();
 
-		this.lineLength = this.lineLengthInput.value;
 		this.updateLineLabels();
 	}
 
@@ -31,8 +31,12 @@ class CharCounter {
 
 	listenForLineChanges() {
 		this.lineInputs.forEach(input => {
-			input.addEventListener('input', this.onLineChange.bind(this));
+			this.attachToInput(input);
 		})
+	}
+
+	attachToInput(input) {
+		input.addEventListener('input', this.onLineChange.bind(this));
 	}
 
 	listenForLineLengthChanges() {
@@ -96,5 +100,13 @@ class CharCounter {
 
 	document.addEventListener('DOMContentLoaded', () => {
 		charCounter.onDomLoaded();
+	});
+
+	document.addEventListener('formset:added', (event) =>
+	{
+		const newInputs = event.target.querySelectorAll(charCounter.inputSelector);
+		newInputs.forEach(input => {
+			charCounter.attachToInput(input);
+		});
 	});
 })();


### PR DESCRIPTION
attach the line-count controls up to the controls when a new, empty line gets added.
for example, from the "add a new line" link button.