### PR TITLE
save the actual models, not the relation/reverse manager

### DIFF
--- a/puzzles/models.py
+++ b/puzzles/models.py
@@ -161,10 +161,11 @@ class Puzzle(models.Model):
     if menu:
       menu.updated_at = timezone.now()
       menu.save()
-    daily_puzzle = getattr(self, 'puzzle_on_date', None)
-    if daily_puzzle:
-      daily_puzzle.updated_at = timezone.now()
-      daily_puzzle.save()
+    daily_puzzle_manger = getattr(self, 'puzzle_on_date', None)
+    if daily_puzzle_manger:
+      for daily_puzzle in daily_puzzle_manger.all():
+        daily_puzzle.updated_at = timezone.now()
+        daily_puzzle.save()
 
 
 


### PR DESCRIPTION
This pull request modifies the `save` method in the `puzzles/models.py` file to handle multiple puzzles associated with the `puzzle_on_date` attribute. The change ensures that all puzzles in the manager are updated and saved, rather than just a single puzzle.

### Changes to `save` method:

* Renamed the `daily_puzzle` variable to `daily_puzzle_manger` for clarity and updated its usage to iterate over all puzzles in the manager (`[puzzles/models.pyL164-R166](diffhunk://#diff-fdacb1422b8f8f2e6a9f5bb81c5cdd218c8aed04c4db02080d7216661c295c61L164-R166)`).